### PR TITLE
Play next N messages

### DIFF
--- a/rosbag2_interfaces/srv/PlayNext.srv
+++ b/rosbag2_interfaces/srv/PlayNext.srv
@@ -1,2 +1,3 @@
+uint64 num_messages 1 # backwards compatible, default value is 1
 ---
 bool success  # can only play-next while playback is paused

--- a/rosbag2_transport/include/rosbag2_transport_backport/player.hpp
+++ b/rosbag2_transport/include/rosbag2_transport_backport/player.hpp
@@ -122,6 +122,9 @@ public:
   bool set_rate(double);
 
   /// \brief Playing next message from queue when in pause.
+  /// \param num_messages The number of messages to play from the queue. It is
+  /// nullopt by default which makes it just take one. When zero, it'll just
+  /// make the method return true.
   /// \details This is blocking call and it will wait until next available message will be
   /// published or rclcpp context shut down.
   /// \note If internal player queue is starving and storage has not been completely loaded,
@@ -129,7 +132,7 @@ public:
   /// \return true if Player::play() has been started, player in pause mode and successfully
   /// played next message, otherwise false.
   ROSBAG2_TRANSPORT_PUBLIC
-  bool play_next();
+  bool play_next(const std::optional<uint64_t> num_messages = std::nullopt);
 
 protected:
   std::atomic<bool> playing_messages_from_queue_{false};

--- a/rosbag2_transport/src/rosbag2_transport/player.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.cpp
@@ -359,7 +359,7 @@ rosbag2_storage::SerializedBagMessageSharedPtr * Player::peek_next_message_from_
   return message_ptr;
 }
 
-bool Player::play_next(std::optional<uint64_t> num_messages)
+bool Player::play_next(const std::optional<uint64_t> num_messages)
 {
   // Evaluates the escape condition in which no message is required to be published.
   if (num_messages.has_value() && *num_messages == 0) {

--- a/rosbag2_transport/src/rosbag2_transport/player.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.cpp
@@ -396,6 +396,8 @@ bool Player::play_next(const std::optional<uint64_t> num_messages)
     if (!next_message_published) {
       break;
     }
+    // next_message_published becomes true when the message is effectively
+    // published (i.e. there is a matching publisher for that message topic).
     message_countdown--;
   }
   return next_message_published;

--- a/rosbag2_transport/src/rosbag2_transport/player.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.cpp
@@ -179,10 +179,10 @@ Player::Player(
     "~/play_next",
     [this](
       const std::shared_ptr<rmw_request_id_t>/* request_header */,
-      const std::shared_ptr<rosbag2_interfaces_backport::srv::PlayNext::Request>/* request */,
+      const std::shared_ptr<rosbag2_interfaces_backport::srv::PlayNext::Request> request,
       const std::shared_ptr<rosbag2_interfaces_backport::srv::PlayNext::Response> response)
     {
-      response->success = play_next();
+      response->success = play_next({request->num_messages});
     });
   srv_play_for_ = create_service<rosbag2_interfaces_backport::srv::PlayFor>(
     "~/play_for",

--- a/rosbag2_transport/src/rosbag2_transport/player.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.cpp
@@ -257,7 +257,9 @@ void Player::do_play(
   // This is a faulty condition. This method must be called exclusively with
   // one or none of the attributes set, but not both.
   if (duration.has_value() && timestamp.has_value()) {
-    RCLCPP_ERROR(this->get_logger(), "Failed to play. Both duration and 'until' timestamp are set.");
+    RCLCPP_ERROR(
+      this->get_logger(),
+      "Failed to play. Both duration and 'until' timestamp are set.");
     return;
   }
 
@@ -357,8 +359,13 @@ rosbag2_storage::SerializedBagMessageSharedPtr * Player::peek_next_message_from_
   return message_ptr;
 }
 
-bool Player::play_next()
+bool Player::play_next(std::optional<uint64_t> num_messages)
 {
+  // Evaluates the escape condition in which no message is required to be published.
+  if (num_messages.has_value() && *num_messages == 0) {
+    return true;
+  }
+
   // Temporary take over playback from play_messages_from_queue()
   std::lock_guard<std::mutex> lk(skip_message_in_main_play_loop_mutex_);
 
@@ -366,18 +373,30 @@ bool Player::play_next()
     return false;
   }
 
-  skip_message_in_main_play_loop_ = true;
-  rosbag2_storage::SerializedBagMessageSharedPtr * message_ptr = peek_next_message_from_queue();
+  bool next_message_published{false};
+  uint64_t message_countdown = num_messages.has_value() ? *num_messages : 1u;
 
-  bool next_message_published = false;
-  while (message_ptr != nullptr && !next_message_published) {
-    {
-      rosbag2_storage::SerializedBagMessageSharedPtr message = *message_ptr;
-      next_message_published = publish_message(message);
-      clock_->jump(message->time_stamp);
+  while (message_countdown > 0) {
+    // Resets state for the new iteration.
+    next_message_published = false;
+    skip_message_in_main_play_loop_ = true;
+    // Grabs a message and tries to publish it. When there is no publisher with
+    // the message->topic_name, it just peeks the next one.
+    rosbag2_storage::SerializedBagMessageSharedPtr * message_ptr = peek_next_message_from_queue();
+    while (message_ptr != nullptr && !next_message_published) {
+      {
+        rosbag2_storage::SerializedBagMessageSharedPtr message = *message_ptr;
+        next_message_published = publish_message(message);
+        clock_->jump(message->time_stamp);
+      }
+      message_queue_.pop();
+      message_ptr = peek_next_message_from_queue();
     }
-    message_queue_.pop();
-    message_ptr = peek_next_message_from_queue();
+    // There are no more messages of the built publishers to play.
+    if (!next_message_published) {
+      break;
+    }
+    message_countdown--;
   }
   return next_message_published;
 }

--- a/rosbag2_transport/test/rosbag2_transport/test_play_next.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_next.cpp
@@ -188,6 +188,69 @@ TEST_F(RosBag2PlayTestFixture, play_next_playing_one_by_one_messages_with_the_sa
   EXPECT_THAT(replayed_topic1, SizeIs(messages.size()));
 }
 
+TEST_F(RosBag2PlayTestFixture, play_next_n_messages_with_the_same_timestamp) {
+  auto primitive_message = get_messages_basic_types()[0];
+  primitive_message->int32_value = 42;
+
+  auto topic_types = std::vector<rosbag2_storage::TopicMetadata>{
+    {"topic1", "test_msgs/BasicTypes", "", ""}};
+
+  std::vector<std::shared_ptr<rosbag2_storage::SerializedBagMessage>> messages =
+  {
+    serialize_test_message("topic1", 1000, primitive_message),
+    serialize_test_message("topic1", 1000, primitive_message),
+    serialize_test_message("topic1", 1000, primitive_message),
+    serialize_test_message("topic1", 1000, primitive_message)
+  };
+
+  auto prepared_mock_reader = std::make_unique<MockSequentialReader>();
+  prepared_mock_reader->prepare(messages, topic_types);
+  auto reader = std::make_unique<rosbag2_cpp::Reader>(std::move(prepared_mock_reader));
+  auto player = std::make_shared<MockPlayer>(std::move(reader), storage_options_, play_options_);
+
+  sub_ = std::make_shared<SubscriptionManager>();
+  sub_->add_subscription<test_msgs::msg::BasicTypes>("/topic1", messages.size());
+
+  // Wait for discovery to match publishers with subscribers
+  ASSERT_TRUE(
+    sub_->spin_and_wait_for_matched(player->get_list_of_publishers(), std::chrono::seconds(30)));
+
+  auto await_received_messages = sub_->spin_subscriptions();
+
+  player->pause();
+  ASSERT_TRUE(player->is_paused());
+
+  auto player_future = std::async(std::launch::async, [&player]() -> void {player->play();});
+  player->wait_for_playback_to_start();
+
+  ASSERT_TRUE(player->is_paused());
+  ASSERT_TRUE(player->play_next({1u}));
+  // Yield CPU resources so messages are actually sent through.
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  EXPECT_THAT(sub_->get_received_messages<test_msgs::msg::BasicTypes>("/topic1"), SizeIs(1u));
+
+  ASSERT_TRUE(player->is_paused());
+  ASSERT_TRUE(player->play_next({2u}));
+  // Yield CPU resources so messages are actually sent through.
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  EXPECT_THAT(sub_->get_received_messages<test_msgs::msg::BasicTypes>("/topic1"), SizeIs(3u));
+
+  ASSERT_TRUE(player->is_paused());
+  ASSERT_TRUE(player->play_next({1u}));
+  // Yield CPU resources so messages are actually sent through.
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  EXPECT_THAT(sub_->get_received_messages<test_msgs::msg::BasicTypes>("/topic1"), SizeIs(4u));
+
+  ASSERT_TRUE(player->is_paused());
+  ASSERT_FALSE(player->play_next({1u}));
+  EXPECT_THAT(sub_->get_received_messages<test_msgs::msg::BasicTypes>("/topic1"), SizeIs(4u));
+
+  ASSERT_TRUE(player->is_paused());
+  player->resume();
+  player_future.get();
+  await_received_messages.get();
+}
+
 TEST_F(RosBag2PlayTestFixture, play_respect_messages_timing_after_play_next) {
   auto primitive_message = get_messages_basic_types()[0];
   primitive_message->int32_value = 42;
@@ -356,4 +419,48 @@ TEST_F(RosBag2PlayTestFixture, play_next_playing_only_filtered_topics) {
   auto replayed_topic2 = sub_->get_received_messages<test_msgs::msg::Arrays>("/topic2");
   // All we care is that any messages arrived
   EXPECT_THAT(replayed_topic2, SizeIs(Eq(3u)));
+}
+
+TEST_F(RosBag2PlayTestFixture, play_next_no_message_must_success) {
+  auto primitive_message = get_messages_basic_types()[0];
+  primitive_message->int32_value = 42;
+
+  auto topic_types = std::vector<rosbag2_storage::TopicMetadata>{
+    {"topic1", "test_msgs/BasicTypes", "", ""}};
+
+  std::vector<std::shared_ptr<rosbag2_storage::SerializedBagMessage>> messages =
+  {
+    serialize_test_message("topic1", 1000, primitive_message)
+  };
+
+  auto prepared_mock_reader = std::make_unique<MockSequentialReader>();
+  prepared_mock_reader->prepare(messages, topic_types);
+  auto reader = std::make_unique<rosbag2_cpp::Reader>(std::move(prepared_mock_reader));
+  auto player = std::make_shared<MockPlayer>(std::move(reader), storage_options_, play_options_);
+
+  sub_ = std::make_shared<SubscriptionManager>();
+  sub_->add_subscription<test_msgs::msg::BasicTypes>("/topic1", messages.size());
+
+  // Wait for discovery to match publishers with subscribers
+  ASSERT_TRUE(
+    sub_->spin_and_wait_for_matched(player->get_list_of_publishers(), std::chrono::seconds(30)));
+
+  auto await_received_messages = sub_->spin_subscriptions();
+
+  player->pause();
+  ASSERT_TRUE(player->is_paused());
+
+  auto player_future = std::async(std::launch::async, [&player]() -> void {player->play();});
+  player->wait_for_playback_to_start();
+
+  ASSERT_TRUE(player->is_paused());
+  ASSERT_TRUE(player->play_next({0u}));
+  // Yield CPU resources so messages are actually sent through.
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  EXPECT_THAT(sub_->get_received_messages<test_msgs::msg::BasicTypes>("/topic1"), SizeIs(0u));
+
+  ASSERT_TRUE(player->is_paused());
+  player->resume();
+  player_future.get();
+  await_received_messages.get();
 }

--- a/rosbag2_transport/test/rosbag2_transport/test_play_next.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_next.cpp
@@ -421,7 +421,7 @@ TEST_F(RosBag2PlayTestFixture, play_next_playing_only_filtered_topics) {
   EXPECT_THAT(replayed_topic2, SizeIs(Eq(3u)));
 }
 
-TEST_F(RosBag2PlayTestFixture, play_next_no_message_must_success) {
+TEST_F(RosBag2PlayTestFixture, play_next_no_message_must_succeed) {
   auto primitive_message = get_messages_basic_types()[0];
   primitive_message->int32_value = 42;
 


### PR DESCRIPTION
- Modifies the Player interface to accept an optional parameter stating the number of messages to play.
- Modifies the the PlayNext.srv message to receive the number of messages to play. Default is 1.
- Tests were included to verify affected code.