### PR TITLE
Play for the next SEC seconds

### DIFF
--- a/rosbag2_test_common/include/rosbag2_test_common_backport/subscription_manager.hpp
+++ b/rosbag2_test_common/include/rosbag2_test_common_backport/subscription_manager.hpp
@@ -141,6 +141,11 @@ public:
       });
   }
 
+  void clear_received_messages_for(const std::string & topic_name)
+  {
+    subscribed_messages_[topic_name].clear();
+  }
+
 private:
   bool continue_spinning(
     const std::unordered_map<std::string, size_t> & expected_topics_with_sizes,

--- a/rosbag2_transport/CMakeLists.txt
+++ b/rosbag2_transport/CMakeLists.txt
@@ -109,6 +109,14 @@ function(create_tests_for_rmw_implementation)
     AMENT_DEPS test_msgs rosbag2_test_common_backport
     ${SKIP_TEST})
 
+  rosbag2_transport_add_gmock(test_play_for_the_next
+    src/rosbag2_transport/qos.cpp
+    test/rosbag2_transport/test_play_for_the_next.cpp
+    INCLUDE_DIRS $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/rosbag2_transport>
+    LINK_LIBS rosbag2_transport_backport
+    AMENT_DEPS test_msgs rosbag2_test_common_backport
+    ${SKIP_TEST})
+
   rosbag2_transport_add_gmock(test_play_loop
     test/rosbag2_transport/test_play_loop.cpp
     LINK_LIBS rosbag2_transport_backport

--- a/rosbag2_transport/include/rosbag2_transport_backport/player.hpp
+++ b/rosbag2_transport/include/rosbag2_transport_backport/player.hpp
@@ -183,6 +183,7 @@ private:
   rclcpp::Service<rosbag2_interfaces_backport::srv::SetRate>::SharedPtr srv_set_rate_;
   rclcpp::Service<rosbag2_interfaces_backport::srv::PlayNext>::SharedPtr srv_play_next_;
   rclcpp::Service<rosbag2_interfaces_backport::srv::PlayFor>::SharedPtr srv_play_for_;
+  rclcpp::Service<rosbag2_interfaces_backport::srv::PlayFor>::SharedPtr srv_play_for_the_next_;
   rclcpp::Service<rosbag2_interfaces_backport::srv::PlayUntil>::SharedPtr srv_play_until_;
 
   template<typename AllocatorT = std::allocator<void>>

--- a/rosbag2_transport/include/rosbag2_transport_backport/player.hpp
+++ b/rosbag2_transport/include/rosbag2_transport_backport/player.hpp
@@ -131,13 +131,13 @@ public:
   ROSBAG2_TRANSPORT_PUBLIC
   bool play_next();
 
-  /// \brief Playing for the next \p duration messages from queue when in pause.
-  /// \details This is blocking call and it will wait up to \p duration for available messages
-  /// to be published or rclcpp context shut down.
+  /// \brief Play the next \p duration of messages from the queue when paused.
+  /// \details This is a blocking call and it will wait up to \p duration for available messages
+  /// to be published or the rclcpp context shut down.
   /// \param duration The time the player must play messages.
-  /// \note If internal player queue is starving and storage has not been completely loaded,
-  /// this method will wait until new element will be pushed to the queue.
-  /// \return true if Player::play() has been started, player in pause mode and successfully
+  /// \note If the internal player queue is starved and storage has not been completely loaded,
+  /// this method will wait until a new element is pushed to the queue.
+  /// \return true if Player::play() has been started, the player is in pause mode and successfully
   /// played messages (at least one) for the specified \p duration, otherwise false.
   ROSBAG2_TRANSPORT_PUBLIC
   bool play_for_the_next(const rcutils_duration_value_t duration);

--- a/rosbag2_transport/include/rosbag2_transport_backport/player.hpp
+++ b/rosbag2_transport/include/rosbag2_transport_backport/player.hpp
@@ -131,6 +131,17 @@ public:
   ROSBAG2_TRANSPORT_PUBLIC
   bool play_next();
 
+  /// \brief Playing for the next \p duration messages from queue when in pause.
+  /// \details This is blocking call and it will wait up to \p duration for available messages
+  /// to be published or rclcpp context shut down.
+  /// \param duration The time the player must play messages.
+  /// \note If internal player queue is starving and storage has not been completely loaded,
+  /// this method will wait until new element will be pushed to the queue.
+  /// \return true if Player::play() has been started, player in pause mode and successfully
+  /// played messages (at least one) for the specified \p duration, otherwise false.
+  ROSBAG2_TRANSPORT_PUBLIC
+  bool play_for_the_next(const rcutils_duration_value_t duration);
+
 protected:
   std::atomic<bool> playing_messages_from_queue_{false};
   rclcpp::Publisher<rosgraph_msgs::msg::Clock>::SharedPtr clock_publisher_;

--- a/rosbag2_transport/src/rosbag2_transport/player.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.cpp
@@ -257,7 +257,9 @@ void Player::do_play(
   // This is a faulty condition. This method must be called exclusively with
   // one or none of the attributes set, but not both.
   if (duration.has_value() && timestamp.has_value()) {
-    RCLCPP_ERROR(this->get_logger(), "Failed to play. Both duration and 'until' timestamp are set.");
+    RCLCPP_ERROR(
+      this->get_logger(),
+      "Failed to play. Both duration and 'until' timestamp are set.");
     return;
   }
 
@@ -380,6 +382,53 @@ bool Player::play_next()
     message_ptr = peek_next_message_from_queue();
   }
   return next_message_published;
+}
+
+bool Player::play_for_the_next(const rcutils_duration_value_t duration)
+{
+  // Temporary take over playback from play_messages_from_queue()
+  std::lock_guard<std::mutex> lk(skip_message_in_main_play_loop_mutex_);
+
+  // Evaluates preconditions.
+  if (!clock_->is_paused() || !is_in_play_ || duration == 0) {
+    return false;
+  }
+
+  bool next_message_published{false};
+  bool timeout_happend{false};
+  bool has_played_at_least_one_message{false};
+
+  const rcutils_time_point_value_t play_until_time = clock_->now() + duration;
+
+  while (!timeout_happend) {
+    // Resets state for the new iteration.
+    next_message_published = false;
+    skip_message_in_main_play_loop_ = true;
+    // Grabs a message and tries to publish it. When there is no publisher with
+    // the message->topic_name, it just peeks the next one.
+    rosbag2_storage::SerializedBagMessageSharedPtr * message_ptr = peek_next_message_from_queue();
+    while (message_ptr != nullptr && !next_message_published) {
+      if ((*message_ptr)->time_stamp <= play_until_time) {
+        rosbag2_storage::SerializedBagMessageSharedPtr message = *message_ptr;
+        next_message_published = publish_message(message);
+        has_played_at_least_one_message = true;
+        clock_->jump(message->time_stamp);
+      } else {
+        // Should break the iteration loop due to timeout.
+        timeout_happend = true;
+        break;
+      }
+      message_queue_.pop();
+      message_ptr = peek_next_message_from_queue();
+    }
+    // There are no more messages of the built publishers to play.
+    if (!next_message_published) {
+      break;
+    }
+  }
+  // Make sure to move the time cursor up to play_until_time.
+  clock_->jump(play_until_time);
+  return has_played_at_least_one_message;
 }
 
 void Player::wait_for_filled_queue() const

--- a/rosbag2_transport/src/rosbag2_transport/player.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.cpp
@@ -198,6 +198,19 @@ Player::Player(
       play({duration});
       response->success = true;
     });
+  srv_play_for_the_next_  = create_service<rosbag2_interfaces_backport::srv::PlayFor>(
+    "~/play_for_the_next",
+    [this](
+      const std::shared_ptr<rmw_request_id_t>/* request_header */,
+      const std::shared_ptr<rosbag2_interfaces_backport::srv::PlayFor::Request> request,
+      const std::shared_ptr<rosbag2_interfaces_backport::srv::PlayFor::Response> response)
+    {
+      const rcutils_duration_value_t duration =
+      static_cast<rcutils_duration_value_t>(request->duration.sec) *
+      static_cast<rcutils_duration_value_t>(1000000000) +
+      static_cast<rcutils_duration_value_t>(request->duration.nanosec);
+      response->success = play_for_the_next(duration);
+    });
   srv_play_until_ = create_service<rosbag2_interfaces_backport::srv::PlayUntil>(
     "~/play_until",
     [this](

--- a/rosbag2_transport/src/rosbag2_transport/player.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.cpp
@@ -198,7 +198,7 @@ Player::Player(
       play({duration});
       response->success = true;
     });
-  srv_play_for_the_next_  = create_service<rosbag2_interfaces_backport::srv::PlayFor>(
+  srv_play_for_the_next_ = create_service<rosbag2_interfaces_backport::srv::PlayFor>(
     "~/play_for_the_next",
     [this](
       const std::shared_ptr<rmw_request_id_t>/* request_header */,

--- a/rosbag2_transport/test/rosbag2_transport/test_play_for_the_next.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_for_the_next.cpp
@@ -1,0 +1,302 @@
+// Copyright 2021 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include <gmock/gmock.h>
+
+#include <chrono>
+#include <future>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "rosbag2_play_test_fixture.hpp"
+#include "rosbag2_transport_backport/player.hpp"
+#include "test_msgs/message_fixtures.hpp"
+#include "test_msgs/msg/arrays.hpp"
+#include "test_msgs/msg/basic_types.hpp"
+
+using namespace ::testing;  // NOLINT
+using namespace rosbag2_transport;  // NOLINT
+using namespace rosbag2_test_common;  // NOLINT
+
+constexpr rcutils_duration_value_t MilliSecondsToDuration(uint64_t milliseconds)
+{
+  return std::chrono::nanoseconds(milliseconds * 1000000u).count();
+}
+
+class MockPlayer : public rosbag2_transport::Player
+{
+public:
+  MockPlayer(
+    std::unique_ptr<rosbag2_cpp::Reader> reader,
+    const rosbag2_storage::StorageOptions & storage_options,
+    const rosbag2_transport::PlayOptions & play_options)
+  : Player(std::move(reader), storage_options, play_options)
+  {}
+
+  std::vector<rclcpp::PublisherBase *> get_list_of_publishers()
+  {
+    std::vector<rclcpp::PublisherBase *> pub_list;
+    for (const auto & publisher : publishers_) {
+      pub_list.push_back(static_cast<rclcpp::PublisherBase *>(publisher.second.get()));
+    }
+    return pub_list;
+  }
+
+  void wait_for_playback_to_start()
+  {
+    while (!playing_messages_from_queue_) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+  }
+};
+
+class RosBag2PlayForTheNextTestFixture : public RosBag2PlayTestFixture
+{
+public:
+  static constexpr int kIntValue{32};
+
+  static constexpr float kFloat1Value{40.};
+  static constexpr float kFloat2Value{2.};
+  static constexpr float kFloat3Value{0.};
+
+  static constexpr bool kBool1Value{false};
+  static constexpr bool kBool2Value{true};
+  static constexpr bool kBool3Value{false};
+
+  static constexpr const char * kTopic1Name{"topic1"};
+  static constexpr const char * kTopic2Name{"topic2"};
+  static constexpr const char * kTopic1{"/topic1"};
+  static constexpr const char * kTopic2{"/topic2"};
+
+  std::vector<rosbag2_storage::TopicMetadata> get_topic_types()
+  {
+    return {{kTopic1Name, "test_msgs/BasicTypes", "", ""},
+      {kTopic2Name, "test_msgs/Arrays", "", ""}};
+  }
+
+  std::vector<rosbag2_storage::TopicMetadata> get_topic_type()
+  {
+    return {{kTopic1Name, "test_msgs/BasicTypes", "", ""}};
+  }
+
+  std::vector<std::shared_ptr<rosbag2_storage::SerializedBagMessage>>
+  get_serialized_messages_for_one_topic()
+  {
+    auto primitive_message = get_messages_basic_types()[0];
+    primitive_message->int32_value = kIntValue;
+
+    // @{ Ordering matters. The mock reader implementation moves messages
+    //    around without any knowledge about message chronology. It just picks
+    //    the next one Make sure to keep the list in order or sort it!
+    return std::vector<std::shared_ptr<rosbag2_storage::SerializedBagMessage>>
+           {serialize_test_message(kTopic1Name, 1000, primitive_message),
+             serialize_test_message(kTopic1Name, 1500, primitive_message),
+             serialize_test_message(kTopic1Name, 2000, primitive_message),
+             serialize_test_message(kTopic1Name, 2500, primitive_message)};
+    // @}
+  }
+
+  std::vector<std::shared_ptr<rosbag2_storage::SerializedBagMessage>>
+  get_serialized_messages_for_two_topics()
+  {
+    auto primitive_message = get_messages_basic_types()[0];
+    primitive_message->int32_value = kIntValue;
+
+    auto complex_message = get_messages_arrays()[0];
+    complex_message->float32_values = {{kFloat1Value, kFloat2Value, kFloat3Value}};
+    complex_message->bool_values = {{kBool1Value, kBool2Value, kBool3Value}};
+
+    // @{ Ordering matters. The mock reader implementation moves messages
+    //    around without any knowledge about message chronology. It just picks
+    //    the next one Make sure to keep the list in order or sort it!
+    return std::vector<std::shared_ptr<rosbag2_storage::SerializedBagMessage>>
+           {serialize_test_message(kTopic2Name, 500, complex_message),
+             serialize_test_message(kTopic1Name, 1000, primitive_message),
+             serialize_test_message(kTopic2Name, 1400, complex_message),
+             serialize_test_message(kTopic1Name, 1500, primitive_message),
+             serialize_test_message(kTopic2Name, 2000, complex_message),
+             serialize_test_message(kTopic1Name, 2000, primitive_message),
+             serialize_test_message(kTopic1Name, 2500, primitive_message),
+             serialize_test_message(kTopic2Name, 2700, complex_message)};
+    // @}
+  }
+};
+
+TEST_F(RosBag2PlayForTheNextTestFixture, play_for_the_next_with_false_preconditions) {
+  auto prepared_mock_reader = std::make_unique<MockSequentialReader>();
+  prepared_mock_reader->prepare(get_serialized_messages_for_one_topic(), get_topic_type());
+  auto reader = std::make_unique<rosbag2_cpp::Reader>(std::move(prepared_mock_reader));
+  auto player = std::make_shared<MockPlayer>(std::move(reader), storage_options_, play_options_);
+
+  ASSERT_FALSE(player->is_paused());
+  ASSERT_FALSE(player->play_for_the_next(0));
+  ASSERT_FALSE(player->play_for_the_next(MilliSecondsToDuration(1200u)));
+
+  player->pause();
+
+  ASSERT_TRUE(player->is_paused());
+  ASSERT_FALSE(player->play_for_the_next(0));
+  ASSERT_FALSE(player->play_for_the_next(MilliSecondsToDuration(2000u)));
+}
+
+TEST_F(RosBag2PlayForTheNextTestFixture, play_for_the_next_duration_which_plays_all_messages) {
+  auto messages = get_serialized_messages_for_one_topic();
+
+  auto prepared_mock_reader = std::make_unique<MockSequentialReader>();
+  prepared_mock_reader->prepare(messages, get_topic_type());
+  auto reader = std::make_unique<rosbag2_cpp::Reader>(std::move(prepared_mock_reader));
+  auto player = std::make_shared<MockPlayer>(std::move(reader), storage_options_, play_options_);
+
+  sub_ = std::make_shared<SubscriptionManager>();
+  sub_->add_subscription<test_msgs::msg::BasicTypes>(kTopic1, messages.size());
+
+  // Wait for discovery to match publishers with subscribers
+  ASSERT_TRUE(
+    sub_->spin_and_wait_for_matched(player->get_list_of_publishers(), std::chrono::seconds(30)));
+
+  auto await_received_messages = sub_->spin_subscriptions();
+
+  player->pause();
+
+  ASSERT_TRUE(player->is_paused());
+
+  auto player_future = std::async(std::launch::async, [&player]() -> void {player->play();});
+  player->wait_for_playback_to_start();
+
+  ASSERT_TRUE(player->play_for_the_next(MilliSecondsToDuration(3000u)));
+  ASSERT_TRUE(player->is_paused());
+
+  player->resume();
+  player_future.get();
+  await_received_messages.get();
+
+  auto replayed_topic1 = sub_->get_received_messages<test_msgs::msg::BasicTypes>(kTopic1);
+  EXPECT_THAT(replayed_topic1, SizeIs(4u));
+}
+
+TEST_F(RosBag2PlayForTheNextTestFixture, play_for_the_next_duration_which_plays_some_messages) {
+  auto messages = get_serialized_messages_for_one_topic();
+
+  auto prepared_mock_reader = std::make_unique<MockSequentialReader>();
+  prepared_mock_reader->prepare(messages, get_topic_type());
+  auto reader = std::make_unique<rosbag2_cpp::Reader>(std::move(prepared_mock_reader));
+  auto player = std::make_shared<MockPlayer>(std::move(reader), storage_options_, play_options_);
+
+  sub_ = std::make_shared<SubscriptionManager>();
+  sub_->add_subscription<test_msgs::msg::BasicTypes>(kTopic1, messages.size());
+
+  // Wait for discovery to match publishers with subscribers
+  ASSERT_TRUE(
+    sub_->spin_and_wait_for_matched(player->get_list_of_publishers(), std::chrono::seconds(30)));
+
+  auto await_received_messages = sub_->spin_subscriptions();
+
+  player->pause();
+
+  ASSERT_TRUE(player->is_paused());
+
+  auto player_future = std::async(std::launch::async, [&player]() -> void {player->play();});
+  player->wait_for_playback_to_start();
+
+  // Should play only one message.
+  ASSERT_TRUE(player->play_for_the_next(MilliSecondsToDuration(1200u)));
+  ASSERT_TRUE(player->is_paused());
+
+  // Should not play any message.
+  ASSERT_FALSE(player->play_for_the_next(MilliSecondsToDuration(100u)));
+  ASSERT_TRUE(player->is_paused());
+
+  // Should play one message.
+  ASSERT_TRUE(player->play_for_the_next(MilliSecondsToDuration(300u)));
+  ASSERT_TRUE(player->is_paused());
+
+  // Continues with the rest of the messages.
+  player->resume();
+  player_future.get();
+  await_received_messages.get();
+
+  auto replayed_topic1 = sub_->get_received_messages<test_msgs::msg::BasicTypes>(kTopic1);
+  EXPECT_THAT(replayed_topic1, SizeIs(4u));
+}
+
+
+TEST_F(RosBag2PlayForTheNextTestFixture, play_for_the_next_duration_with_filtered_topics) {
+  auto prepared_mock_reader = std::make_unique<MockSequentialReader>();
+  prepared_mock_reader->prepare(get_serialized_messages_for_two_topics(), get_topic_types());
+  auto reader = std::make_unique<rosbag2_cpp::Reader>(std::move(prepared_mock_reader));
+
+  // Skips topic2, allows only topic1.
+  play_options_.topics_to_filter = {kTopic1Name};
+  auto player = std::make_shared<MockPlayer>(std::move(reader), storage_options_, play_options_);
+
+  sub_ = std::make_shared<SubscriptionManager>();
+  sub_->add_subscription<test_msgs::msg::BasicTypes>(kTopic1, 4);
+  sub_->add_subscription<test_msgs::msg::Arrays>(kTopic2, 0);
+
+  // Wait for discovery to match publishers with subscribers
+  ASSERT_TRUE(
+    sub_->spin_and_wait_for_matched(player->get_list_of_publishers(), std::chrono::seconds(30)));
+
+  auto await_received_messages = sub_->spin_subscriptions();
+
+  player->pause();
+
+  ASSERT_TRUE(player->is_paused());
+
+  auto player_future = std::async(std::launch::async, [&player]() -> void {player->play();});
+  player->wait_for_playback_to_start();
+
+  // Should not play any message. Time cursor: 600ms
+  ASSERT_FALSE(player->play_for_the_next(MilliSecondsToDuration(600u)));
+  ASSERT_TRUE(player->is_paused());
+
+  // Should play only one message. Time cursor: 1100ms
+  ASSERT_TRUE(player->play_for_the_next(MilliSecondsToDuration(500u)));
+  ASSERT_TRUE(player->is_paused());
+
+  // Should not play any message. Time cursor: 1450ms
+  ASSERT_FALSE(player->play_for_the_next(MilliSecondsToDuration(350u)));
+  ASSERT_TRUE(player->is_paused());
+
+  // Should play only one message. Time cursor: 1550ms
+  ASSERT_TRUE(player->play_for_the_next(MilliSecondsToDuration(100u)));
+  ASSERT_TRUE(player->is_paused());
+
+  // Should not play any message because there are none. Time cursor: 1950ms
+  ASSERT_FALSE(player->play_for_the_next(MilliSecondsToDuration(400u)));
+  ASSERT_TRUE(player->is_paused());
+
+  // Should play one message from topic1 only. Time cursor: 2050ms
+  ASSERT_TRUE(player->play_for_the_next(MilliSecondsToDuration(100u)));
+  ASSERT_TRUE(player->is_paused());
+
+  // Should play one message. Time cursor: 2650ms
+  ASSERT_TRUE(player->play_for_the_next(MilliSecondsToDuration(600u)));
+  ASSERT_TRUE(player->is_paused());
+
+  // Should not play any message. Time cursor: 2850ms
+  ASSERT_FALSE(player->play_for_the_next(MilliSecondsToDuration(200u)));
+  ASSERT_TRUE(player->is_paused());
+
+  // Continues with the rest of the messages.
+  player->resume();
+  player_future.get();
+  await_received_messages.get();
+
+  auto replayed_topic1 = sub_->get_received_messages<test_msgs::msg::BasicTypes>(kTopic1);
+  EXPECT_THAT(replayed_topic1, SizeIs(4u));
+
+  auto replayed_topic2 = sub_->get_received_messages<test_msgs::msg::BasicTypes>(kTopic2);
+  EXPECT_THAT(replayed_topic2, SizeIs(0u));
+}


### PR DESCRIPTION
Adds a new method to the Player which allows to step for a certain duration the player and play all filtered messages within that time.

A new service which has the same type (`PlayFor`) as `/play_for` service has been created: `/play_for_the_next`. It just forwards the duration packed in the request to `Play::play_for_the_next()`.