### PR TITLE
Make rosdep work again

### DIFF
--- a/ros2bag/package.xml
+++ b/ros2bag/package.xml
@@ -13,7 +13,7 @@
   <license>Apache License 2.0</license>
 
   <depend>ros2cli</depend>
-  <depend>rosbag2_py</depend>
+  <depend>rosbag2_py_backport</depend>
   <depend>rosbag2_transport</depend>
 
   <test_depend>ament_copyright</test_depend>


### PR DESCRIPTION
Changes a dependency to make rosdep work again.

Note that I had to fork and clone [keyboard_handler](https://github.com/agalbachicar/keyboard_handler/tree/foxy-compatible) repository as well into the workspace.

~~No colcon build has been run at all, just rosdep~~

```bash
$ colcon build --event-handlers console_direct+
[...]
Summary: 17 packages finished [4.18s]

$ colcon test --event-handlers console_direct+ --packages-skip keyboard_handler
agalbachicar@higgs:~/ros2_foxy_ws$ colcon test-result
build/rosbag2_compression_backport/Testing/20220207-1331/Test.xml: 10 tests, 0 errors, 2 failures, 0 skipped
build/rosbag2_compression_backport/test_results/rosbag2_compression_backport/cpplint.xunit.xml: 35 tests, 0 errors, 14 failures, 0 skipped
build/rosbag2_compression_backport/test_results/rosbag2_compression_backport/test_sequential_compression_writer.gtest.xml: 1 test, 1 error, 0 failures, 0 skipped
build/rosbag2_compression_zstd_backport/Testing/20220207-1332/Test.xml: 7 tests, 0 errors, 1 failure, 0 skipped
build/rosbag2_compression_zstd_backport/test_results/rosbag2_compression_zstd_backport/cpplint.xunit.xml: 12 tests, 0 errors, 6 failures, 0 skipped
build/rosbag2_cpp_backport/Testing/20220207-1331/Test.xml: 17 tests, 0 errors, 2 failures, 0 skipped
build/rosbag2_cpp_backport/test_results/rosbag2_cpp_backport/cpplint.xunit.xml: 109 tests, 0 errors, 67 failures, 0 skipped
build/rosbag2_cpp_backport/test_results/rosbag2_cpp_backport/uncrustify.xunit.xml: 74 tests, 0 errors, 1 failure, 0 skipped
build/rosbag2_py_backport/Testing/20220207-1334/Test.xml: 14 tests, 0 errors, 5 failures, 0 skipped
build/rosbag2_py_backport/test_results/rosbag2_py_backport/flake8.xunit.xml: 1 test, 0 errors, 1 failure, 0 skipped
build/rosbag2_py_backport/test_results/rosbag2_py_backport/test_reindexer_py.xunit.xml: 1 test, 1 error, 0 failures, 0 skipped
build/rosbag2_py_backport/test_results/rosbag2_py_backport/test_sequential_reader_multiple_files_py.xunit.xml: 3 tests, 0 errors, 3 failures, 0 skipped
build/rosbag2_py_backport/test_results/rosbag2_py_backport/test_sequential_reader_py.xunit.xml: 3 tests, 0 errors, 1 failure, 0 skipped
build/rosbag2_py_backport/test_results/rosbag2_py_backport/test_transport_py.xunit.xml: 2 tests, 0 errors, 2 failures, 0 skipped
build/rosbag2_storage_backport/Testing/20220207-1331/Test.xml: 10 tests, 0 errors, 1 failure, 0 skipped
build/rosbag2_storage_backport/test_results/rosbag2_storage_backport/cpplint.xunit.xml: 53 tests, 0 errors, 38 failures, 0 skipped
build/rosbag2_storage_default_plugins_backport/Testing/20220207-1331/Test.xml: 8 tests, 0 errors, 1 failure, 0 skipped
build/rosbag2_storage_default_plugins_backport/test_results/rosbag2_storage_default_plugins_backport/cpplint.xunit.xml: 19 tests, 0 errors, 12 failures, 0 skipped
build/rosbag2_test_common_backport/Testing/20220207-1331/Test.xml: 6 tests, 0 errors, 1 failure, 0 skipped
build/rosbag2_test_common_backport/test_results/rosbag2_test_common_backport/cpplint.xunit.xml: 16 tests, 0 errors, 16 failures, 0 skipped
build/rosbag2_tests_backport/Testing/20220207-1332/Test.xml: 12 tests, 0 errors, 4 failures, 0 skipped
build/rosbag2_tests_backport/test_results/rosbag2_tests_backport/test_reindex.gtest.xml: 1 test, 1 error, 0 failures, 0 skipped
build/rosbag2_tests_backport/test_results/rosbag2_tests_backport/test_rosbag2_info_end_to_end.gtest.xml: 3 tests, 0 errors, 1 failure, 0 skipped
build/rosbag2_tests_backport/test_results/rosbag2_tests_backport/test_rosbag2_play_end_to_end.gtest.xml: 3 tests, 0 errors, 1 failure, 0 skipped
build/rosbag2_tests_backport/test_results/rosbag2_tests_backport/test_rosbag2_record_end_to_end.gtest.xml: 1 test, 1 error, 0 failures, 0 skipped
build/rosbag2_transport_backport/Testing/20220207-1332/Test.xml: 25 tests, 0 errors, 9 failures, 0 skipped
build/rosbag2_transport_backport/test_results/rosbag2_transport_backport/cpplint.xunit.xml: 63 tests, 0 errors, 30 failures, 0 skipped
build/rosbag2_transport_backport/test_results/rosbag2_transport_backport/test_play_seek__rmw_fastrtps_cpp.gtest.xml: 5 tests, 0 errors, 4 failures, 0 skipped
build/rosbag2_transport_backport/test_results/rosbag2_transport_backport/test_record__rmw_fastrtps_cpp.gtest.xml: 6 tests, 0 errors, 4 failures, 0 skipped
build/rosbag2_transport_backport/test_results/rosbag2_transport_backport/test_record_all__rmw_fastrtps_cpp.gtest.xml: 1 test, 0 errors, 1 failure, 0 skipped
build/rosbag2_transport_backport/test_results/rosbag2_transport_backport/test_record_all_ignore_leaf_topics__rmw_fastrtps_cpp.gtest.xml: 1 test, 0 errors, 1 failure, 0 skipped
build/rosbag2_transport_backport/test_results/rosbag2_transport_backport/test_record_regex__rmw_fastrtps_cpp.gtest.xml: 2 tests, 0 errors, 2 failures, 0 skipped
build/rosbag2_transport_backport/test_results/rosbag2_transport_backport/test_record_services__rmw_fastrtps_cpp.gtest.xml: 1 test, 1 error, 0 failures, 0 skipped
build/rosbag2_transport_backport/test_results/rosbag2_transport_backport/test_rewrite.gtest.xml: 4 tests, 0 errors, 1 failure, 0 skipped
build/rosbag2_transport_backport/test_results/rosbag2_transport_backport/uncrustify.xunit.xml: 49 tests, 0 errors, 4 failures, 0 skipped

Summary: 2033 tests, 5 errors, 236 failures, 0 skipped
```