### PR TITLE
foxy clock qos fix

### DIFF
--- a/rosbag2_transport/src/rosbag2_transport/clock_qos.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/clock_qos.cpp
@@ -20,7 +20,7 @@ namespace rosbag2_transport
 ClockQoS::ClockQoS(const rclcpp::QoSInitialization & qos_initialization)
 // Using `rmw_qos_profile_sensor_data` intentionally.
 // It's best effort and `qos_initialization` is overriding the depth to 1.
-: QoS(qos_initialization, rmw_qos_profile_sensor_data)
+: QoS(qos_initialization, rmw_qos_profile_default)
 {}
 
 }  // namespace rosbag2_transport


### PR DESCRIPTION
I assume that this `galactic-backport` branch should run on ros2 foxy. This one-liner fix is related to the https://github.com/ros2/rclcpp/pull/1312

Tldr, there’s a switch from qos reliable (default) to best_effort (galactic) when upgrading from foxy to galactic. The mismatch of qos will cause the DDS subscriber to ignore the publisher. This fix reverts the qos back to default.