### PR TITLE
fix clock qos and py mod names for bp

### DIFF
--- a/ros2bag/ros2bag_backport/command/bag.py
+++ b/ros2bag/ros2bag_backport/command/bag.py
@@ -24,7 +24,7 @@ class BagCommand(CommandExtension):
 
         # get verb extensions and let them add their arguments
         add_subparsers_on_demand(
-            parser, cli_name, '_verb', 'ros2bag.verb', required=False)
+            parser, cli_name, '_verb', 'ros2bag_backport.verb', required=False)
 
     def main(self, *, parser, args):
         if not hasattr(args, '_verb'):

--- a/ros2bag/ros2bag_backport/verb/convert.py
+++ b/ros2bag/ros2bag_backport/verb/convert.py
@@ -14,9 +14,9 @@
 
 import argparse
 
-from ros2bag.verb import VerbExtension
-from rosbag2_py import bag_rewrite
-from rosbag2_py import StorageOptions
+from ros2bag_backport.verb import VerbExtension
+from rosbag2_py_backport import bag_rewrite
+from rosbag2_py_backport import StorageOptions
 
 
 class ConvertVerb(VerbExtension):

--- a/ros2bag/ros2bag_backport/verb/info.py
+++ b/ros2bag/ros2bag_backport/verb/info.py
@@ -14,7 +14,7 @@
 
 import os
 
-from ros2bag.verb import VerbExtension
+from ros2bag_backport.verb import VerbExtension
 
 
 class InfoVerb(VerbExtension):

--- a/ros2bag/ros2bag_backport/verb/list.py
+++ b/ros2bag/ros2bag_backport/verb/list.py
@@ -19,7 +19,7 @@ from xml.dom import minidom
 from ament_index_python import get_resource
 from ament_index_python import get_resources
 
-from ros2bag.verb import VerbExtension
+from ros2bag_backport.verb import VerbExtension
 
 
 class ListVerb(VerbExtension):

--- a/ros2bag/ros2bag_backport/verb/play.py
+++ b/ros2bag/ros2bag_backport/verb/play.py
@@ -15,16 +15,16 @@
 from argparse import FileType
 
 from rclpy.qos import InvalidQoSProfileException
-from ros2bag.api import check_path_exists
-from ros2bag.api import check_positive_float
-from ros2bag.api import convert_yaml_to_qos_profile
-from ros2bag.api import print_error
-from ros2bag.verb import VerbExtension
+from ros2bag_backport.api import check_path_exists
+from ros2bag_backport.api import check_positive_float
+from ros2bag_backport.api import convert_yaml_to_qos_profile
+from ros2bag_backport.api import print_error
+from ros2bag_backport.verb import VerbExtension
 from ros2cli.node import NODE_NAME_PREFIX
-from rosbag2_py import get_registered_readers
-from rosbag2_py import Player
-from rosbag2_py import PlayOptions
-from rosbag2_py import StorageOptions
+from rosbag2_py_backport import get_registered_readers
+from rosbag2_py_backport import Player
+from rosbag2_py_backport import PlayOptions
+from rosbag2_py_backport import StorageOptions
 import yaml
 
 

--- a/ros2bag/ros2bag_backport/verb/record.py
+++ b/ros2bag/ros2bag_backport/verb/record.py
@@ -17,16 +17,16 @@ import datetime
 import os
 
 from rclpy.qos import InvalidQoSProfileException
-from ros2bag.api import convert_yaml_to_qos_profile
-from ros2bag.api import print_error
-from ros2bag.verb import VerbExtension
+from ros2bag_backport.api import convert_yaml_to_qos_profile
+from ros2bag_backport.api import print_error
+from ros2bag_backport.verb import VerbExtension
 from ros2cli.node import NODE_NAME_PREFIX
-from rosbag2_py import get_registered_compressors
-from rosbag2_py import get_registered_serializers
-from rosbag2_py import get_registered_writers
-from rosbag2_py import Recorder
-from rosbag2_py import RecordOptions
-from rosbag2_py import StorageOptions
+from rosbag2_py_backport import get_registered_compressors
+from rosbag2_py_backport import get_registered_serializers
+from rosbag2_py_backport import get_registered_writers
+from rosbag2_py_backport import Recorder
+from rosbag2_py_backport import RecordOptions
+from rosbag2_py_backport import StorageOptions
 import yaml
 
 

--- a/rosbag2_transport/src/rosbag2_transport/player.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.cpp
@@ -445,7 +445,7 @@ public:
   explicit
   ClockQoS(
     const rclcpp::QoSInitialization & qos_initialization = rclcpp::KeepLast(1))
-  : QoS(qos_initialization, rmw_qos_profile_sensor_data)
+  : QoS(qos_initialization, rmw_qos_profile_default)
   {}
 };
 


### PR DESCRIPTION
Tested on ros2 foxy env

- Fix py backport module names
- Fix clock qos related to: https://github.com/gbiggs/rosbag2/pull/13

Note: Separate issue, when I tested `ros2 bag_bp play FILE  --start-offset 10.0` , the bag started from time point 10s. However during init, some stray msgs from time < 10s will get published. This is a bp version so expected some features will not work well.